### PR TITLE
Updated variable name for Go syntax

### DIFF
--- a/naming.md
+++ b/naming.md
@@ -20,7 +20,7 @@ This page summarises some of the key programming primitives of pSpaces and their
 | search all tuples | `queryAll` | `List<Object[]> tl = s.queryAll(new ActualField("a"),new FormalField(Integer.class())` |  | `tl,e := s.QueryAll("a",&x)` | `let t = s.queryAll(["a",FormalTemplateField(Int.self)])` |  |
 | wait for tuple and remove | `get` | `Object[] t = s.get(new ActualField("a"),new FormalField(Integer.class())` |  | `t,e := s.Get("a",&x)` | `let t = s.get(["a",FormalTemplateField(Int.self)])` |  |
 | remove tuple | `getP` | `Object[] t = s.getP(new ActualField("a"),new FormalField(Integer.class())` |  | `t,e := s.GetP("a",&x)` | `let t = s.getp(["a",FormalTemplateField(Int.self)])` |  |
-| remove all tuples | `getAll` | `List<Object[]> tl = s.getAll(new ActualField("a"),new FormalField(Integer.class())` |  | `t,e := s.GetAll("a",&x)` | `let t = s.getAll(["a",FormalTemplateField(Int.self)])` |  |
+| remove all tuples | `getAll` | `List<Object[]> tl = s.getAll(new ActualField("a"),new FormalField(Integer.class())` |  | `tl,e := s.GetAll("a",&x)` | `let t = s.getAll(["a",FormalTemplateField(Int.self)])` |  |
 
 ## Spaces and repositories
 


### PR DESCRIPTION
Changed variable name 't' to 'tl' as GetAll will return a list of tuples.